### PR TITLE
Fix registry check

### DIFF
--- a/lib/ezclient/persistent_client.rb
+++ b/lib/ezclient/persistent_client.rb
@@ -5,8 +5,6 @@ class EzClient::PersistentClient
 
   def_delegators :http_client, :build_request, :default_options, :timeout
 
-  attr_accessor :origin, :keep_alive_timeout, :last_request_at
-
   def initialize(origin, keep_alive_timeout)
     self.origin = origin
     self.keep_alive_timeout = keep_alive_timeout
@@ -19,7 +17,13 @@ class EzClient::PersistentClient
     end
   end
 
+  def timed_out?
+    last_request_at && EzClient.get_time - last_request_at >= keep_alive_timeout
+  end
+
   private
+
+  attr_accessor :origin, :keep_alive_timeout, :last_request_at
 
   def http_client
     @http_client ||= HTTP.persistent(origin, timeout: keep_alive_timeout)

--- a/lib/ezclient/persistent_client_registry.rb
+++ b/lib/ezclient/persistent_client_registry.rb
@@ -16,8 +16,6 @@ class EzClient::PersistentClientRegistry
   attr_accessor :registry
 
   def cleanup_registry!
-    registry.delete_if do |_key, value|
-      EzClient.get_time - value.last_request_at >= value.keep_alive_timeout
-    end
+    registry.delete_if { |_origin, client| client.timed_out? }
   end
 end

--- a/lib/ezclient/version.rb
+++ b/lib/ezclient/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EzClient
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/spec/ezclient_spec.rb
+++ b/spec/ezclient_spec.rb
@@ -235,6 +235,7 @@ RSpec.describe EzClient do
       it "sends proper Connection header" do
         expect(request.headers).to include("Connection" => "Keep-Alive")
         expect(request.url).to eq("http://example.com")
+        second_request = client.request(:get, "http://example2.com")
         response = request.perform!
         expect(response.body).to eq("some body")
       end

--- a/spec/ezclient_spec.rb
+++ b/spec/ezclient_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe EzClient do
       it "sends proper Connection header" do
         expect(request.headers).to include("Connection" => "Keep-Alive")
         expect(request.url).to eq("http://example.com")
-        second_request = client.request(:get, "http://example2.com")
+        client.request(:get, "http://example2.com")
         response = request.perform!
         expect(response.body).to eq("some body")
       end


### PR DESCRIPTION
In case when we do `client.request` without calling `perform` on it, next request was raising `nil can't be coerced into Float` since `last_request_at` was nil.