### PR TITLE
Add elapsed_seconds to request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ request.verb # => "POST"
 request.url # => "http://example.com"
 request.body # => '{"a": 1}'
 request.headers # => { "Content-Type" => "application/json; charset=UTF-8", ... }
+request.elapsed_seconds # => 0.08117745001072763
 ```
 
 ## Response object

--- a/lib/ezclient/request.rb
+++ b/lib/ezclient/request.rb
@@ -21,15 +21,12 @@ class EzClient::Request
   end
 
   def perform
-    perform_started_at = EzClient.get_time
     http_response = perform_request
-    self.elapsed_seconds = EzClient.get_time - perform_started_at
 
     EzClient::Response.new(http_response).tap do |response|
       on_complete.call(self, response, options[:metadata])
     end
   rescue => error
-    self.elapsed_seconds = EzClient.get_time - perform_started_at
     on_error.call(self, error, options[:metadata])
     raise error
   end
@@ -104,6 +101,7 @@ class EzClient::Request
   end
 
   def perform_request
+    perform_started_at = EzClient.get_time
     with_retry do
       # Use original client so that connection can be reused
       res = client.perform(http_request, http_options)
@@ -113,6 +111,8 @@ class EzClient::Request
         client.perform(request, http_options)
       end
     end
+  ensure
+    self.elapsed_seconds = EzClient.get_time - perform_started_at
   end
 
   def with_retry(&block)

--- a/lib/ezclient/request.rb
+++ b/lib/ezclient/request.rb
@@ -29,6 +29,7 @@ class EzClient::Request
       on_complete.call(self, response, options[:metadata])
     end
   rescue => error
+    self.elapsed_seconds = EzClient.get_time - perform_started_at
     on_error.call(self, error, options[:metadata])
     raise error
   end

--- a/lib/ezclient/request.rb
+++ b/lib/ezclient/request.rb
@@ -10,7 +10,7 @@ class EzClient::Request
     query
   ].freeze
 
-  attr_accessor :verb, :url, :options
+  attr_accessor :verb, :url, :options, :elapsed_seconds
 
   def initialize(verb, url, options)
     self.verb = verb.to_s.upcase
@@ -21,7 +21,9 @@ class EzClient::Request
   end
 
   def perform
+    perform_started_at = EzClient.get_time
     http_response = perform_request
+    self.elapsed_seconds = EzClient.get_time - perform_started_at
 
     EzClient::Response.new(http_response).tap do |response|
       on_complete.call(self, response, options[:metadata])

--- a/spec/ezclient_spec.rb
+++ b/spec/ezclient_spec.rb
@@ -259,6 +259,7 @@ RSpec.describe EzClient do
       let(:on_error) do
         proc do |request, error, metadata|
           expect(request.url).to eq("http://example.com")
+          expect(request.elapsed_seconds).to be_a(Float)
           expect(error).to be_a(StandardError)
           expect(metadata).to eq(:smth)
           calls << nil

--- a/spec/ezclient_spec.rb
+++ b/spec/ezclient_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe EzClient do
       expect(request.verb).to eq("POST")
       expect(request.url).to eq("http://example.com")
       expect(request.body).to eq("a=1")
+      expect(request.elapsed_seconds).to be_a(Float)
 
       expect(request.headers).to eq(
         "Connection" => "close",


### PR DESCRIPTION
I have added elapsed_seconds to request object for statistical and monitoring purposes.