### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version
+        id: version
+        run: |
+          version=$(grep -oP '(?<=VERSION = ")[^"]+' lib/ezclient/version.rb)
+          echo "tag=v$version" >> $GITHUB_OUTPUT
+
+      - name: Check if release already exists
+        id: check
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" &>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ruby/setup-ruby@v1
+        if: steps.check.outputs.exists == 'false'
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Build gem
+        if: steps.check.outputs.exists == 'false'
+        run: gem build ezclient.gemspec
+
+      - name: Push gem to RubyGems
+        if: steps.check.outputs.exists == 'false'
+        run: gem push *.gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
+
+      - uses: softprops/action-gh-release@v3
+        if: steps.check.outputs.exists == 'false'
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          files: "*.gem"
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automates the release process when changes are pushed to `master`.

## What it does

1. **Extracts version** from `lib/ezclient/version.rb`
2. **Checks if release already exists** to avoid duplicate runs
3. **Builds the gem** using `gem build`
4. **Pushes to RubyGems** using `GEM_HOST_API_KEY` secret
5. **Creates a GitHub Release** with auto-generated notes and the `.gem` file attached

All steps after the existence check are gated on the release not already existing, so re-running the workflow is safe.

## Required secrets

- `GEM_HOST_API_KEY` — RubyGems API key for pushing the gem

🤖 Generated with [Claude Code](https://claude.com/claude-code)